### PR TITLE
Register a filter via twig extension

### DIFF
--- a/EventListener/FormSubscriber.php
+++ b/EventListener/FormSubscriber.php
@@ -105,11 +105,6 @@ class FormSubscriber implements EventSubscriberInterface
             'contactfield' => $lead->getProfileFields(),
         ];
 
-        // TWIG filter json_decode
-        $this->twig->addFilter(new TwigFilter('unescape', function ($string) {
-            return html_entity_decode($string);
-        }));
-
         $this->leadModel->setFieldValues(
             $lead,
             [$config['field'] => $this->twig->createTemplate($config['syntax'])->render($fields)],

--- a/Twig/Extension/ContentExtension.php
+++ b/Twig/Extension/ContentExtension.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\MauticFormActionsBundle\Twig\Extension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+final class ContentExtension extends AbstractExtension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters()
+    {
+        return [
+            new TwigFilter('unescape', fn (string $string) => html_entity_decode($string)),
+        ];
+    }
+}


### PR DESCRIPTION
Adding an action to a form multiple times, such as twice, causes a twig filter registration error. 
```
[2023-07-31T11:33:56.680359+00:00] mautic.CRITICAL: Uncaught PHP Exception LogicException: "Filter "unescape" is already registered." at /var/www/html/vendor/twig/twig/src/Extension/StagingExtension.php line 52 {"exception":"[object] (LogicException(code: 0): Filter \"unescape\" is already registered. at /var/www/html/vendor/twig/twig/src/Extension/StagingExtension.php:52)
```

This PR moves the twig filter to a separate extension to fix this error.